### PR TITLE
Correct Punctuation in Workflow Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
     * [currency.getgeoapi.com](https://currency.getgeoapi.com) → get your API key [here](https://currency.getgeoapi.com/currency-plans/) (preferred)
 
-    * [exchangeratesapi.io](https://exchangeratesapi.io) → get your API key [here](https://manage.exchangeratesapi.io/signup/free) (please also see [issue #8](https://github.com/littlebrighter/alfred--ultimate-currency-converter/issues/8) for recent changes restricting the free plan of this API)
+    * [exchangeratesapi.io](https://exchangeratesapi.io) → get your API key [here](https://manage.exchangeratesapi.io/signup/free) (please also see [issue #8](https://github.com/littlebrighter/alfred-ultimate-currency-converter/issues/8) for recent changes restricting the free plan of this API)
 
     * [currencyconverterapi.com](https://currencyconverterapi.com) → get your API key from [here](https://free.currencyconverterapi.com/free-api-key), usage is limited by number of requests per hour, also: precision is limited to few digits
 
@@ -35,7 +35,7 @@ in Terminal.app
 
 Installation is as easy as downloading the workflow and double-clicking it to call Alfred.
 
-In order to do so, head over to the [latest release](https://github.com/littlebrighter/alfred--ultimate-currency-converter/releases/latest) and fetch the `Ultimate.Currency.Converter.v*.alfredworkflow` file, e.g. download it to your Mac. Double-click the file and you will be guided to Alfred.app which asks you, if you want to install this workflow.
+In order to do so, head over to the [latest release](../../releases/latest) and fetch the `Ultimate.Currency.Converter.v*.alfredworkflow` file, e.g. download it to your Mac. Double-click the file and you will be guided to Alfred.app which asks you, if you want to install this workflow.
 
 ## Usage
 
@@ -136,4 +136,4 @@ This workflow was heavily inspired and is based partly on the source code of big
 
 ### License
 
-Released under [MIT License](https://github.com/littlebrighter/alfred--ultimate-currency-converter/blob/main/LICENSE)
+Released under [MIT License](https://github.com/littlebrighter/alfred-ultimate-currency-converter/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The best Alfred Workflow for Converting Currencies. Period.
+# The best Alfred Workflow for Converting Currencies, period.
 
 <img src="https://littlebrighter.erevo.io/alfred/img/ultimate-currency-converter/workflow.png" width="764">
 

--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>io.erevo.littlebrighter.alfred--ultimate-currency-converter</string>
+	<string>io.erevo.littlebrighter.alfred-ultimate-currency-converter</string>
 	<key>category</key>
 	<string>Tools</string>
 	<key>connections</key>
@@ -198,7 +198,7 @@
 				<key>spaces</key>
 				<string></string>
 				<key>url</key>
-				<string>https://github.com/littlebrighter/alfred--ultimate-currency-converter/releases/latest</string>
+				<string>https://github.com/littlebrighter/alfred-ultimate-currency-converter/releases/latest</string>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.action.openurl</string>
@@ -807,7 +807,7 @@ $PHP_BINARY -f e4WorkflowApp.php -- "set to {query}" "save"</string>
 	<key>readme</key>
 	<string># Ultimate Currency Converter
 
-Please have a look at our [README](https://github.com/littlebrighter/alfred--ultimate-currency-converter/) on GitHub before using for the first time.
+Please have a look at our [README](https://github.com/littlebrighter/alfred-ultimate-currency-converter/) on GitHub before using for the first time.
 
 ## Prerequisites
 
@@ -816,14 +816,14 @@ Please have a look at our [README](https://github.com/littlebrighter/alfred--ult
 
     * **[currency.getgeoapi.com](https://currency.getgeoapi.com)** → get your API key [here](https://currency.getgeoapi.com/currency-plans/) (preferred)
 
-    * [exchangeratesapi.io](https://exchangeratesapi.io) → get your API key [here](https://manage.exchangeratesapi.io/signup/free) (please also see [issue #8](https://github.com/littlebrighter/alfred--ultimate-currency-converter/issues/8) for recent changes restricting the free plan of this API)
+    * [exchangeratesapi.io](https://exchangeratesapi.io) → get your API key [here](https://manage.exchangeratesapi.io/signup/free) (please also see [issue #8](https://github.com/littlebrighter/alfred-ultimate-currency-converter/issues/8) for recent changes restricting the free plan of this API)
 
     * [currencyconverterapi.com](https://currencyconverterapi.com) → get your API key from [here](https://free.currencyconverterapi.com/free-api-key), usage is limited by number of requests per hour, also: precision is limited to few digits
 
 
 ## Prerequisites for users of macOS Monterey 12.0 and later
 
-Apple no longer ships php bundled with macOS from Monterey 12.0, so you need to install php manually. Our recommendation is to go with homebrew. Alfred has built-in support for php from [homebrew](https://brew.sh). Please see [our GitHub repository](https://github.com/littlebrighter/alfred--ultimate-currency-converter/) if you need support with getting php to run.
+Apple no longer ships php bundled with macOS from Monterey 12.0, so you need to install php manually. Our recommendation is to go with homebrew. Alfred has built-in support for php from [homebrew](https://brew.sh). Please see [our GitHub repository](https://github.com/littlebrighter/alfred-ultimate-currency-converter/) if you need support with getting php to run.
 
 ## Usage
 
@@ -835,7 +835,7 @@ You can trigger this workflow in the Alfred window with the following keyword:
 
 Ultimate Currency Converter accepts simple and complex queries.
 
-The workflow uses two settings. A default **from**-currency and a default **to**-currency. Everytime you start the workflow without explicitely specifying one or both currencies needed for a conversion, Ultimate Currency Converter tries to guess what you intent to do by completing your query with the default ones. See [our GitHub repository](https://github.com/littlebrighter/alfred--ultimate-currency-converter/) for changing default currencies.
+The workflow uses two settings. A default **from**-currency and a default **to**-currency. Everytime you start the workflow without explicitely specifying one or both currencies needed for a conversion, Ultimate Currency Converter tries to guess what you intent to do by completing your query with the default ones. See [our GitHub repository](https://github.com/littlebrighter/alfred-ultimate-currency-converter/) for changing default currencies.
 
 #### Most simple example
 
@@ -853,11 +853,11 @@ You get the idea: look at the first example: no second currency is given, so the
 
 ### More on usage …
 
-Please have a look at our [README](https://github.com/littlebrighter/alfred--ultimate-currency-converter/) on GitHub.
+Please have a look at our [README](https://github.com/littlebrighter/alfred-ultimate-currency-converter/) on GitHub.
 
 ### License
 
-Released under [MIT License](https://github.com/littlebrighter/alfred--ultimate-currency-converter/blob/main/LICENSE)</string>
+Released under [MIT License](https://github.com/littlebrighter/alfred-ultimate-currency-converter/blob/main/LICENSE)</string>
 	<key>uidata</key>
 	<dict>
 		<key>009D1F46-8846-44E9-A114-410D7CAC0335</key>
@@ -1143,6 +1143,6 @@ Released under [MIT License](https://github.com/littlebrighter/alfred--ultimate-
 	<key>version</key>
 	<string>1.13.2</string>
 	<key>webaddress</key>
-	<string>https://github.com/littlebrighter/alfred--ultimate-currency-converter</string>
+	<string>https://github.com/littlebrighter/alfred-ultimate-currency-converter</string>
 </dict>
 </plist>

--- a/info.plist
+++ b/info.plist
@@ -179,7 +179,7 @@
 	<key>createdby</key>
 	<string>Little Brighter</string>
 	<key>description</key>
-	<string>The best Alfred Workflow for Converting Currencies. Period.</string>
+	<string>The best Alfred Workflow for Converting Currencies, period.</string>
 	<key>disabled</key>
 	<false/>
 	<key>name</key>


### PR DESCRIPTION
I love this workflow but…when using “period” as an emphatic tag at the end of a statement, it works best with a comma. I mean, if you insert another period, then the sentence ends where _it_ is placed instead, feels less punchy. 

<img width="484" alt="Screenshot 2025-03-18 at 1 50 20 PM" src="https://github.com/user-attachments/assets/1433c7af-d880-4bc4-9913-81b5e300da5a" />

Please also fix it in the description of the repo. 

<img width="251" alt="Screenshot 2025-03-18 at 1 53 32 PM" src="https://github.com/user-attachments/assets/1087362c-1613-4114-a1f1-1b6b7bf8d3e6" />



There’s also a hyphen in the repo’s name that is followed by another. Sorry, I just couldn’t unsee this. I’ve done the replacement for you. All you have to do is to change the name of the repo yourself. 